### PR TITLE
Fix italic icon and text in the building parts library's search bar

### DIFF
--- a/Assets/Prefabs/UI/HeaderSearchbar.prefab
+++ b/Assets/Prefabs/UI/HeaderSearchbar.prefab
@@ -178,7 +178,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 2
+  m_fontStyle: 0
   m_HorizontalAlignment: 1
   m_VerticalAlignment: 512
   m_textAlignment: 65535


### PR DESCRIPTION
Fix italic icon and text in the building parts library's search bar